### PR TITLE
feat: add rabbitmq support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Required service tag `dd-php-fpm`
 
 Required service tag `dd-go-expvar`
 
+### rabbitmq
+
+- `RABBITMQ_TARGET_FILE` (default: `/etc/dd-agent/conf.d/rabbitmq.yaml`) path to the dd-agent `rabbitmq.yaml` file.
+
+Required service tag `dd-rabbitmq`
+
 ### redis
 
 - `REDIS_TARGET_FILE` (default: `/etc/dd-agent/conf.d/redis.yaml`) path to the dd-agent `redis.yaml` file.

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	reloader "github.com/seatgeek/datadog-service-helper/reloader"
 	go_expvar "github.com/seatgeek/datadog-service-helper/services/goexpvar"
 	php_fpm "github.com/seatgeek/datadog-service-helper/services/phpfpm"
+	"github.com/seatgeek/datadog-service-helper/services/rabbitmq"
 	"github.com/seatgeek/datadog-service-helper/services/redisdb"
 	"github.com/seatgeek/datadog-service-helper/services/tcp"
 
@@ -75,6 +76,7 @@ func main() {
 	// start service observers
 	go php_fpm.Observe(payload)
 	go go_expvar.Observe(payload)
+	go rabbitmq.Observe(payload)
 	go redisdb.Observe(payload)
 	go tcp.Observe(payload)
 

--- a/services/rabbitmq/service.go
+++ b/services/rabbitmq/service.go
@@ -1,0 +1,103 @@
+package rabbitmq
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	consul "github.com/hashicorp/consul/api"
+	cfg "github.com/seatgeek/datadog-service-helper/config"
+	"github.com/sirupsen/logrus"
+	yaml "gopkg.in/yaml.v2"
+)
+
+var logger = logrus.New()
+
+// Observe changes in Consul catalog for rabbitmq
+func Observe(payload *cfg.ServicePayload) {
+	filePath := os.Getenv("RABBITMQ_CONFIG_FILE")
+	if filePath == "" {
+		filePath = "/etc/dd-agent/conf.d/rabbitmq.yaml"
+	}
+	password := os.Getenv("RABBITMQ_PASSWORD")
+	if password == "" {
+		password = "guest"
+	}
+	username := os.Getenv("RABBITMQ_USERNAME")
+	if username == "" {
+		username = "guest"
+	}
+
+	currentHash, err := cfg.HashFileMd5(filePath)
+	if err != nil {
+		logger.Warnf("[rabbitmq] Could not get initial hash for %s: %s", filePath, err)
+		currentHash = ""
+	}
+
+	logger.Infof("[rabbitmq] Existing file hash %s: %s", filePath, currentHash)
+
+	stream := payload.Services.Observe()
+
+	for {
+		select {
+		case <-payload.QuitCh:
+			logger.Warn("[rabbitmq] stopping")
+			return
+
+		case <-stream.Changes():
+			stream.Next()
+
+			t := &Config{}
+
+			services := stream.Value().(map[string]*consul.AgentService)
+
+			for _, service := range services {
+				if !cfg.ServiceEnabled("rabbitmq", service.Tags) {
+					logger.Debugf("[rabbitmq] Service %s does not contain 'dd-rabbitmq' tag", service.Service)
+					continue
+				}
+				logger.Infof("[rabbitmq] Service %s tags does contain 'dd-rabbitmq'", service.Service)
+
+				check := &ConfigItem{
+					URL:      fmt.Sprintf("http://%s:%s/api/", service.Address, service.Port),
+					Username: username,
+					Password: password,
+					Tags: []string{
+						fmt.Sprintf("service:%s", service.Service),
+					},
+				}
+
+				t.Instances = append(t.Instances, check)
+			}
+
+			// Sort the services by name so we get consistent output across runs
+			sort.Sort(serviceSorter(t.Instances))
+
+			data, err := yaml.Marshal(&t)
+			if err != nil {
+				logger.Fatalf("[rabbitmq] could not marshal yaml: %v", err)
+			}
+
+			reloadRequired, newHash := cfg.WriteIfChange("rabbitmq", filePath, data, currentHash)
+			if !reloadRequired {
+				currentHash = newHash
+				continue
+			}
+
+			payload.ReloadCh <- cfg.ReloadPayload{
+				Service: "rabbitmq",
+				OldHash: currentHash,
+				NewHash: newHash,
+			}
+
+			currentHash = newHash
+		}
+	}
+}
+
+// serviceSorter sorts planets by ExpvarURL
+type serviceSorter []*ConfigItem
+
+func (a serviceSorter) Len() int           { return len(a) }
+func (a serviceSorter) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a serviceSorter) Less(i, j int) bool { return a[i].URL < a[j].URL }

--- a/services/rabbitmq/structs.go
+++ b/services/rabbitmq/structs.go
@@ -1,0 +1,17 @@
+package rabbitmq
+
+// See https://github.com/DataDog/integrations-core/tree/master/rabbitmq
+
+// Config ...
+type Config struct {
+	InitConfig []string      `yaml:"init_config,flow"`
+	Instances  []*ConfigItem `yaml:"instances"`
+}
+
+// ConfigItem ...
+type ConfigItem struct {
+	URL      string   `yaml:"rabbitmq_api_url"`
+	Username string   `yaml:"rabbitmq_user"`
+	Password string   `yaml:"rabbitmq_pass"`
+	Tags     []string `yaml:"tags"`
+}


### PR DESCRIPTION
Password handling isn't great as it uses an env var and therefore _all_ instances need the same monitoring username/password, but there isn't a great alternative here either.